### PR TITLE
Updated send_sms.py for updated version of twilio

### DIFF
--- a/send_sms.py
+++ b/send_sms.py
@@ -1,8 +1,8 @@
-from twilio.rest import TwilioRestClient
+from twilio.rest import Client
 from credentials import account_sid, auth_token, my_cell, my_twilio
 
 # Find these values at https://twilio.com/user/account
-client = TwilioRestClient(account_sid, auth_token)
+client = Client(account_sid, auth_token)
 
 my_msg = "Your message goes here..."
 


### PR DESCRIPTION
Changed TwilioRestClient To Client as it has been changed with the newer version of twilio. As with TwilioRestClient it was throwing back this error ---- "twilio.base.obsolete.ObsoleteException: TwilioRestClient has been removed from this version of the library."