### PR TITLE
Updated the client class name

### DIFF
--- a/send_sms.py
+++ b/send_sms.py
@@ -1,8 +1,8 @@
-from twilio.rest import TwilioRestClient
+from twilio.rest import Client
 from credentials import account_sid, auth_token, my_cell, my_twilio
 
 # Find these values at https://twilio.com/user/account
-client = TwilioRestClient(account_sid, auth_token)
+client = Client(account_sid, auth_token)
 
 my_msg = "Your message goes here..."
 


### PR DESCRIPTION
In the latest documentation, the TwilioRestClient class is now updated. So, we have to use Client(account_sid, auth_token) for API access.